### PR TITLE
crc32: Fix function definitions on WIN32

### DIFF
--- a/deps/crc32/crc32.c
+++ b/deps/crc32/crc32.c
@@ -24,6 +24,11 @@
 #  define htole16(x) OSSwapHostToLittleInt16(x)
 #  define be16toh(x) OSSwapBigToHostInt16(x)
 #  define le16toh(x) OSSwapLittleToHostInt16(x)
+#elif defined(_WIN32)
+#  define htobe16(x) htons(x)
+#  define htole16(x) (x)
+#  define be16toh(x) ntohs(x)
+#  define le16toh(x) (x)
 #else
 #  include <endian.h>
 #endif


### PR DESCRIPTION
For windows support, we want to send patches separately.
This patch fixes `<endian.h>` not found on Windows.