### PR TITLE
Introduce Windows compat layer

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -28,12 +28,26 @@
 #  include <windows.h>
 #  include <wchar.h>
 #  include <io.h>
+#  include <direct.h>
 #  include <stdint.h>
 #  include <stdlib.h>
 #  define access _access
 #  define W_OK 02 // Write permission.
 #  define mode_t uint32_t
 #  define mkdir(dir, mode) _mkdir(dir)
+
+static inline char* dirname(const char *dir) {
+    char drive[_MAX_DRIVE];
+    char splitted_dir[_MAX_DIR];
+    char filename[_MAX_FNAME];
+    char ext[_MAX_EXT];
+    char path_buffer[_MAX_PATH];
+
+    _splitpath(dir, drive, splitted_dir, filename, ext);
+    _makepath(path_buffer, drive, splitted_dir, "", "");
+
+    return path_buffer;
+}
 #else
 #  include <unistd.h>
 #endif

--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -1,0 +1,34 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Chunk I/O
+ *  =========
+ *  Copyright 2018 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CHUNKIO_COMPAT_H
+#define CHUNKIO_COMPAT_H
+
+/* Windows compatibility utils */
+#ifdef _WIN32
+#  define PATH_MAX MAX_PATH
+#  define ssize_t int
+#  include <winsock2.h>
+#  include <windows.h>
+#  include <wchar.h>
+#else
+#  include <unistd.h>
+#endif
+
+#endif

--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -27,6 +27,13 @@
 #  include <winsock2.h>
 #  include <windows.h>
 #  include <wchar.h>
+#  include <io.h>
+#  include <stdint.h>
+#  include <stdlib.h>
+#  define access _access
+#  define W_OK 02 // Write permission.
+#  define mode_t uint32_t
+#  define mkdir(dir, mode) _mkdir(dir)
 #else
 #  include <unistd.h>
 #endif

--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -20,7 +20,7 @@
 #ifndef CIO_CHUNK_H
 #define CIO_CHUNK_H
 
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <inttypes.h>
 
 struct cio_chunk {

--- a/include/chunkio/cio_os.h
+++ b/include/chunkio/cio_os.h
@@ -19,6 +19,7 @@
 
 #ifndef CIO_OS_H
 #define CIO_OS_H
+#include <chunkio/chunkio_compat.h>
 
 int cio_os_isdir(const char *dir);
 int cio_os_mkpath(const char *dir, mode_t mode);

--- a/src/chunkio.c
+++ b/src/chunkio.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <string.h>
 
 #include <chunkio/chunkio.h>

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -21,6 +21,7 @@
 #include <chunkio/cio_file.h>
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_log.h>
+#include <chunkio/chunkio_compat.h>
 
 #include <string.h>
 

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>

--- a/src/cio_memfs.c
+++ b/src/cio_memfs.c
@@ -20,6 +20,7 @@
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_log.h>
+#include <chunkio/chunkio_compat.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -25,7 +25,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <libgen.h>
+#ifndef _WIN32
+#  include <libgen.h>
+#endif
 
 /* Check if a path is a directory */
 int cio_os_isdir(const char *dir)

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -21,7 +21,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>

--- a/src/cio_stream.c
+++ b/src/cio_stream.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_os.h>

--- a/src/cio_utils.c
+++ b/src/cio_utils.c
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/tools/cio.c
+++ b/tools/cio.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <chunkio/chunkio_compat.h>
 #include <getopt.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
Windows does not have `<unistd.h>`.
When using `#ifdef _WIN32` macro simply, it makes flood of `#ifdef _WIN32`.
Then, we should create compat layer and use it.