### PR TITLE
Add CIO_BACKEND_FILESYSTEM=On/Off to enable/disable filesystem backend support. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(CIO_LIB_STATIC        "Enable static library build"  On)
 option(CIO_LIB_SHARED        "Enable shared library build"  Off)
 option(CIO_SANITIZE_ADDRESS  "Enable address sanitizer"     Off)
 option(CIO_TESTS             "Enable tests"                 Off)
+option(CIO_BACKEND_FILESYSTEM "Enable filesystem backend"   On)
 
 # Force Option value
 macro(CIO_OPTION option value)
@@ -29,6 +30,13 @@ if(CIO_DEV)
   CIO_OPTION(CIO_TESTS                  On)
   CIO_OPTION(CIO_LIB_STATIC             On)
 endif()
+
+# Macro to set definitions
+macro(CIO_DEFINITION var)
+  add_definitions(-D${var})
+  set(CIO_BUILD_FLAGS "${CIO_BUILD_FLAGS}#ifndef ${var}\n#define ${var}\n#endif\n")
+  set(CIO_INFO_FLAGS "${CIO_INFO_FLAGS} ${var}")
+endmacro()
 
 # Check if Address Sanitizer is enabled
 if(CIO_SANITIZE_ADDRESS OR SANITIZE_ADDRESS)
@@ -45,6 +53,10 @@ if(CIO_SANITIZE_ADDRESS OR SANITIZE_ADDRESS)
   else()
     message(STATUS "Enabling address sanitizer")
   endif()
+endif()
+
+if(CIO_BACKEND_FILESYSTEM)
+  CIO_DEFINITION(CIO_HAVE_BACKEND_FILESYSTEM)
 endif()
 
 include_directories(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@ set(src
   cio_os.c
   cio_log.c
   cio_memfs.c
-  cio_file.c
   cio_chunk.c
   cio_meta.c
   cio_scan.c
@@ -10,6 +9,13 @@ set(src
   cio_stream.c
   chunkio.c
   )
+
+if(CIO_BACKEND_FILESYSTEM)
+  set(src
+    ${src}
+    cio_file.c
+    )
+endif()
 
 if(CIO_LIB_STATIC)
   add_library(chunkio-static STATIC ${src})

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -18,7 +18,9 @@
  */
 
 #include <chunkio/chunkio.h>
-#include <chunkio/cio_file.h>
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+#  include <chunkio/cio_file.h>
+#endif
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_log.h>
 
@@ -65,7 +67,14 @@ struct cio_chunk *cio_chunk_open(struct cio_ctx *ctx, struct cio_stream *st,
 
     /* create backend context */
     if (st->type == CIO_STORE_FS) {
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
         backend = cio_file_open(ctx, st, ch, flags, size);
+#else
+        cio_log_error(ctx, "[cio chunk] error initializing backend file. This build does not support file backend.");
+        free(ch->name);
+        free(ch);
+        return NULL;
+#endif
     }
     else if (st->type == CIO_STORE_MEM) {
         backend = cio_memfs_open(ctx, st, ch, flags, size);
@@ -88,12 +97,14 @@ void cio_chunk_close(struct cio_chunk *ch, int delete)
     int type;
 
     type = ch->st->type;
-    if (type == CIO_STORE_FS) {
-        cio_file_close(ch, delete);
-    }
-    else if (type == CIO_STORE_MEM) {
+    if (type == CIO_STORE_MEM) {
         cio_memfs_close(ch);
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+    else if (type == CIO_STORE_FS) {
+        cio_file_close(ch, delete);
+    }
+#endif
 
     mk_list_del(&ch->_head);
     free(ch->name);
@@ -109,17 +120,21 @@ int cio_chunk_write_at(struct cio_chunk *ch, off_t offset,
 {
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     type = ch->st->type;
-    if (type == CIO_STORE_FS) {
-        cf = ch->backend;
-        cf->data_size = offset;
-    }
-    else if (type == CIO_STORE_MEM) {
+    if (type == CIO_STORE_MEM) {
         mf = ch->backend;
         mf->buf_len = offset;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+    else if (type == CIO_STORE_FS) {
+        cf = ch->backend;
+        cf->data_size = offset;
+    }
+#endif
 
     /*
      * By default backends (fs, mem) appends data after the it last position,
@@ -130,16 +145,18 @@ int cio_chunk_write_at(struct cio_chunk *ch, off_t offset,
 
 int cio_chunk_write(struct cio_chunk *ch, const void *buf, size_t count)
 {
-    int ret;
+    int ret = 0;
     int type;
 
     type = ch->st->type;
-    if (type == CIO_STORE_FS) {
-        ret = cio_file_write(ch, buf, count);
-    }
-    else if (type == CIO_STORE_MEM) {
+    if (type == CIO_STORE_MEM) {
         ret = cio_memfs_write(ch, buf, count);
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+    else if (type == CIO_STORE_FS) {
+        ret = cio_file_write(ch, buf, count);
+    }
+#endif
 
     return ret;
 }
@@ -150,27 +167,32 @@ int cio_chunk_sync(struct cio_chunk *ch)
     int type;
 
     type = ch->st->type;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     if (type == CIO_STORE_FS) {
         ret = cio_file_sync(ch);
     }
+#endif
 
     return ret;
 }
 
 int cio_chunk_get_content(struct cio_chunk *ch, char **buf, size_t *size)
 {
-    int ret;
+    int ret = 0;
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     type = ch->st->type;
     if (type == CIO_STORE_MEM) {
         mf = ch->backend;
         *size = mf->buf_len;
         *buf = mf->buf_data;
-        return 0;
+        return ret;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         ret = cio_file_read_prepare(ch->ctx, ch);
@@ -179,8 +201,9 @@ int cio_chunk_get_content(struct cio_chunk *ch, char **buf, size_t *size)
         }
         *size = cf->data_size;
         *buf = cio_file_st_get_content(cf->map);
-        return 0;
+        return ret;
     }
+#endif
 
     return -1;
 }
@@ -190,17 +213,21 @@ size_t cio_chunk_get_content_end_pos(struct cio_chunk *ch)
     int type;
     off_t pos = 0;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     type = ch->st->type;
     if (type == CIO_STORE_MEM) {
         mf = ch->backend;
         pos = (off_t) (mf->buf_data + mf->buf_len);
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         pos = (off_t) (cio_file_st_get_content(cf->map) + cf->data_size);
     }
+#endif
 
     return pos;
 }
@@ -209,17 +236,21 @@ ssize_t cio_chunk_get_content_size(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     type = ch->st->type;
     if (type == CIO_STORE_MEM) {
         mf = ch->backend;
         return mf->buf_len;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         return cf->data_size;
     }
+#endif
 
     return -1;
 }
@@ -228,17 +259,21 @@ ssize_t cio_chunk_get_real_size(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     type = ch->st->type;
     if (type == CIO_STORE_MEM) {
         mf = ch->backend;
         return mf->buf_len;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         return cf->fs_size;
     }
+#endif
 
     return -1;
 }
@@ -257,9 +292,11 @@ void cio_chunk_close_stream(struct cio_stream *st)
 
 char *cio_chunk_hash(struct cio_chunk *ch)
 {
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     if (ch->st->type == CIO_STORE_FS) {
         return cio_file_hash(ch->backend);
     }
+#endif
 
     return NULL;
 }
@@ -298,7 +335,9 @@ int cio_chunk_tx_begin(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     if (cio_chunk_is_locked(ch)) {
         return -1;
@@ -315,11 +354,13 @@ int cio_chunk_tx_begin(struct cio_chunk *ch)
         ch->tx_crc = mf->crc_cur;
         ch->tx_content_length = mf->buf_len;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         ch->tx_crc = cf->crc_cur;
         ch->tx_content_length = cf->data_size;
     }
+#endif
 
     return 0;
 }
@@ -347,7 +388,9 @@ int cio_chunk_tx_rollback(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     struct cio_file *cf;
+#endif
 
     if (ch->tx_active == CIO_TRUE) {
         return -1;
@@ -359,11 +402,13 @@ int cio_chunk_tx_rollback(struct cio_chunk *ch)
         mf->crc_cur = ch->tx_crc;
         mf->buf_len = ch->tx_content_length;
     }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
         cf->crc_cur = ch->tx_crc;
         cf->data_size = ch->tx_content_length;
     }
+#endif
 
     ch->tx_active = CIO_FALSE;
     return 0;

--- a/src/cio_meta.c
+++ b/src/cio_meta.c
@@ -22,12 +22,15 @@
 #include <string.h>
 
 #include <chunkio/chunkio.h>
-#include <chunkio/cio_file.h>
-#include <chunkio/cio_file_st.h>
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+#  include <chunkio/cio_file.h>
+#  include <chunkio/cio_file_st.h>
+#endif
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_stream.h>
 #include <chunkio/cio_log.h>
 
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
 /*
  * Metadata is an optional information stored before the content of each file
  * and can be used for different purposes. Manipulating metadata can have
@@ -64,10 +67,12 @@ static int adjust_layout(struct cio_chunk *ch,
 
     return 0;
 }
+#endif
 
 int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
 {
     int ret;
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     char *meta;
     char *cur_content_data;
     char *new_content_data;
@@ -76,6 +81,7 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
     size_t meta_av;
     void *tmp;
     struct cio_file *cf = ch->backend;
+#endif
     struct cio_memfs *mf;
 
     if (size > 65535) {
@@ -99,6 +105,7 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
         return 0;
     }
 
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     /* Get metadata pointer */
     meta = cio_file_st_get_meta(cf->map);
 
@@ -173,17 +180,34 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
     adjust_layout(ch, cf, size);
 
     return 0;
+#endif // CIO_HAVE_BACKEND_FILESYSTEM
 }
 
 int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
 {
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     int len;
     char *meta;
     struct cio_file *cf;
+#endif
     struct cio_memfs *mf;
 
     /* In-memory type */
-    if (ch->st->type == CIO_STORE_FS) {
+    if (ch->st->type == CIO_STORE_MEM) {
+        mf = (struct cio_memfs *) ch->backend;
+
+        /* no metadata */
+        if (!mf->meta_data) {
+            return -1;
+        }
+
+        *meta_buf = mf->meta_data;
+        *meta_len = mf->meta_len;
+
+        return 0;
+    }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+    else if (ch->st->type == CIO_STORE_FS) {
         cf = ch->backend;
 
         len = cio_file_st_get_meta_len(cf->map);
@@ -197,19 +221,7 @@ int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
 
         return 0;
     }
-    else if (ch->st->type == CIO_STORE_MEM) {
-        mf = (struct cio_memfs *) ch->backend;
-
-        /* no metadata */
-        if (!mf->meta_data) {
-            return -1;
-        }
-
-        *meta_buf = mf->meta_data;
-        *meta_len = mf->meta_len;
-
-        return 0;
-    }
+#endif
 
     return -1;
 
@@ -217,9 +229,11 @@ int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
 
 int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len)
 {
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     int len;
     char *meta;
     struct cio_file *cf = ch->backend;
+#endif
     struct cio_memfs *mf;
 
     /* In-memory type */
@@ -244,7 +258,7 @@ int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len)
         return -1;
     }
 
-
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
     /* File system type */
     len = cio_file_st_get_meta_len(cf->map);
     if (len != meta_len) {
@@ -256,6 +270,7 @@ int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len)
     if (memcmp(meta, meta_buf, meta_len) == 0) {
         return 0;
     }
+#endif
 
     return -1;
 }

--- a/src/cio_scan.c
+++ b/src/cio_scan.c
@@ -26,7 +26,9 @@
 
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_stream.h>
-#include <chunkio/cio_file.h>
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+#  include <chunkio/cio_file.h>
+#endif
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_chunk.h>
 #include <chunkio/cio_log.h>
@@ -133,11 +135,13 @@ void cio_scan_dump(struct cio_ctx *ctx)
         printf(" stream:%-60s%i chunks\n",
                st->name, mk_list_size(&st->files));
 
-        if (st->type == CIO_STORE_FS) {
-            cio_file_scan_dump(ctx, st);
-        }
-        else if (st->type == CIO_STORE_MEM) {
+        if (st->type == CIO_STORE_MEM) {
             cio_memfs_scan_dump(ctx, st);
         }
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
+        else if (st->type == CIO_STORE_FS) {
+            cio_file_scan_dump(ctx, st);
+        }
+#endif
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,13 @@ include_directories(lib/acutest)
 
 set(UNIT_TESTS_FILES
   context.c
-  fs.c
   memfs.c
   )
+if(CIO_BACKEND_FILESYSTEM)
+  set(UNIT_TESTS_FILES
+    fs.c
+    )
+endif()
 
 set(CIO_TESTS_DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/)
 configure_file(


### PR DESCRIPTION
This PR is one of the related tasks for https://github.com/fluent/fluent-bit/issues/960.

---

When `CIO_BACKEND_FILESYSTEM=off`(in-memory mode), chunkio relies on `malloc`.
This change makes easier to port Windows environment.

BTW, in Windows, we also must port directory related API and remove `unistd.h` and other Linux dependent headers usages. I'll try it out later.
~~The above task is progressing on #3.~~ Done. :tada: