### PR TITLE
Implement more compat layer functions

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -51,6 +51,12 @@ static inline char* dirname(const char *dir) {
 #  if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
 #    define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #  endif
+inline int getpagesize(void)
+{
+    SYSTEM_INFO system_info;
+    GetSystemInfo(&system_info);
+    return system_info.dwPageSize;
+}
 #else
 #  include <unistd.h>
 #endif

--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -51,6 +51,7 @@ static inline char* dirname(const char *dir) {
 #  if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
 #    define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #  endif
+#  define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 inline int getpagesize(void)
 {
     SYSTEM_INFO system_info;

--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -48,6 +48,9 @@ static inline char* dirname(const char *dir) {
 
     return path_buffer;
 }
+#  if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#    define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#  endif
 #else
 #  include <unistd.h>
 #endif

--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -25,6 +25,7 @@
 #  define PATH_MAX MAX_PATH
 #  define ssize_t int
 #  include <winsock2.h>
+#  pragma comment(lib, "ws2_32.lib")
 #  include <windows.h>
 #  include <wchar.h>
 #  include <io.h>


### PR DESCRIPTION
* Define alternative S_ISREG macro 
* getpagesize() on Windows
* Use strerror_s instead of strerror_r on Windows for error reporting backend
* Add a missing ws2_32.lib pragma for linking wonsock2 library