### PR TITLE
tools: cio: fix SIGSEGV due to incompatible argument types

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -153,7 +153,8 @@ static void cio_signal_init()
     signal(SIGSEGV, &cio_signal_handler);
 }
 
-static int log_cb(struct cio_ctx *ctx, const char *file, int line,
+
+static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
                   char *str)
 {
     char *dtitle = "chunkio";


### PR DESCRIPTION
Right now, running `tools/cio` instantly fails with SIGSEGV:

    $ echo test | tools/cio -i -s stdin -v -r cio
    [cio] caught signal (SIGSEGV)
    Aborted

Evidently this is caused by b204911 that has modified the log function
interface, but forgot to update the implementation in `tools/cio.c`.

Part of https://github.com/fluent/fluent-bit/issues/960