### PR TITLE
tests: fix SIGSEGV in 'cio-test-fs' and 'cio-test-memfs'

### DIFF
--- a/tests/fs.c
+++ b/tests/fs.c
@@ -34,7 +34,7 @@
 #define CIO_FILE_400KB    CIO_TESTS_DATA_PATH "/data/400kb.txt"
 
 /* Logging callback, once called it just turn on the log_check flag */
-static int log_cb(struct cio_ctx *ctx, const char *file, int line,
+static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
                   char *str)
 {
     (void) ctx;

--- a/tests/memfs.c
+++ b/tests/memfs.c
@@ -35,7 +35,7 @@
 #define CIO_FILE_400KB    CIO_TESTS_DATA_PATH "/data/400kb.txt"
 
 /* Logging callback, once called it just turn on the log_check flag */
-static int log_cb(struct cio_ctx *ctx, const char *file, int line,
+static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
                   char *str)
 {
     (void) ctx;


### PR DESCRIPTION
This fixes the function prototype of the logging function in the
test programs.

With this patch applied, I can confirm all test cases go green on
Linux.

Part of https://github.com/fluent/fluent-bit/issues/960