### PR TITLE
tools: cio: fix up the description of the command line options

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -82,11 +82,14 @@ static void cio_help(int rc)
     printf("  -l, --list\t\tlist environment content\n");
     printf("  -F, --full-sync\tforce data flush to disk\n");
     printf("  -k, --checksum\tenable CRC32 checksum\n");
+    printf("  -f, --filename=FILE\tset name of file to create\n");
     printf("  -p, --perf=FILE\trun performance test\n");
     printf("  -w, --perf-writes=N\tset number of writes for performance mode "
            "(default: 5)\n");
-    printf("  -f, --perf-files=N\tset number of files to create on "
+    printf("  -e, --perf-files=N\tset number of files to create on "
            "performance mode (default: 1000)\n");
+    printf("  -S, --silent\t\tmake chunkio quiet during the operation\n");
+    printf("  -v, --verbose\t\tincrease logging verbosity\n");
     printf("  -h, --help\t\tprint this help\n");
     exit(rc);
 }


### PR DESCRIPTION
This patch syncs the help message with the actual command-line options.

For example, `-f` was incorrectly described to take an integer as
its argument. With this patch these errors should be all cleared away.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>