### PR TITLE
build: Use /W4 instead of /Wall on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(chunk-io)
 # CFLAGS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Wall ")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 ")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall ")
 endif()


### PR DESCRIPTION
The problem is that /Wall is too much verbose on Windows, giving us a
lot of unhelpful feedbacks.

Now, the official VC++ manual recommends to use /W4. Let's just switch
to it.

> We recommend that you use this option to provide lint-like warnings.
> For a new project, it may be best to use /W4 in all compilations;
> this will ensure the fewest possible hard-to-find code defects.
>
> https://docs.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level

Main issue link: https://github.com/fluent/fluent-bit/issues/960