### PR TITLE
build: tweak the build target on CIO_BACKEND_FILESYSTEM=Off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,11 @@ include_directories(
 
 add_subdirectory(deps/crc32)
 add_subdirectory(src)
-add_subdirectory(tools)
+
+# not much useful for memfs-only platforms
+if(CIO_BACKEND_FILESYSTEM)
+  add_subdirectory(tools)
+endif()
 
 if(CIO_TESTS)
   add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ set(src
   cio_chunk.c
   cio_meta.c
   cio_scan.c
-  cio_utils.c
   cio_stream.c
   chunkio.c
   )
@@ -14,6 +13,7 @@ if(CIO_BACKEND_FILESYSTEM)
   set(src
     ${src}
     cio_file.c
+    cio_utils.c
     )
 endif()
 


### PR DESCRIPTION
This is a series of patch to make compilation on Windows easier.

344e18b build: do not build tools/cio if CIO_BACKEND_FILESYSTEM=Off
74ed9d2 build: also don't build "cio_utils.c" if CIO_BACKEND_FILESYSTEM=Off

Part of https://github.com/fluent/fluent-bit/issues/960