### PR TITLE
chunk: include <sys/types.h> explicitly

### DIFF
--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -21,6 +21,7 @@
 #define CIO_CHUNK_H
 
 #include <chunkio/chunkio_compat.h>
+#include <sys/types.h>
 #include <inttypes.h>
 
 struct cio_chunk {


### PR DESCRIPTION
On Linux, <sys/types.h> seems to be included indirectly though some
other headers. However, on Windows it doesn't.

This causes the compilation to fail on MSVC with "unknown type off_t"
errors.

Main issue link: https://github.com/fluent/fluent-bit/issues/960