### PR TITLE
compat: do not expose chunk_compat.h as part of library interface

### DIFF
--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -20,7 +20,6 @@
 #ifndef CIO_CHUNK_H
 #define CIO_CHUNK_H
 
-#include <chunkio/chunkio_compat.h>
 #include <sys/types.h>
 #include <inttypes.h>
 

--- a/include/chunkio/cio_os.h
+++ b/include/chunkio/cio_os.h
@@ -19,7 +19,6 @@
 
 #ifndef CIO_OS_H
 #define CIO_OS_H
-#include <chunkio/chunkio_compat.h>
 
 int cio_os_isdir(const char *dir);
 int cio_os_mkpath(const char *dir, mode_t mode);

--- a/src/chunkio.c
+++ b/src/chunkio.c
@@ -19,9 +19,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <chunkio/chunkio_compat.h>
 #include <string.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_os.h>
 #include <chunkio/cio_log.h>

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -17,11 +17,11 @@
  *  limitations under the License.
  */
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_file.h>
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_log.h>
-#include <chunkio/chunkio_compat.h>
 
 #include <string.h>
 

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -24,13 +24,13 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <chunkio/chunkio_compat.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <arpa/inet.h>
 #include <limits.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_crc32.h>
 #include <chunkio/cio_chunk.h>

--- a/src/cio_log.c
+++ b/src/cio_log.c
@@ -21,6 +21,7 @@
 #include <stdarg.h>
 #include <string.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_log.h>
 

--- a/src/cio_memfs.c
+++ b/src/cio_memfs.c
@@ -17,10 +17,10 @@
  *  limitations under the License.
  */
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_memfs.h>
 #include <chunkio/cio_log.h>
-#include <chunkio/chunkio_compat.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -21,13 +21,14 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <chunkio/chunkio_compat.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #ifndef _WIN32
 #  include <libgen.h>
 #endif
+
+#include <chunkio/chunkio_compat.h>
 
 /* Check if a path is a directory */
 int cio_os_isdir(const char *dir)

--- a/src/cio_utils.c
+++ b/src/cio_utils.c
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <chunkio/chunkio_compat.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -31,6 +30,7 @@
 #include <sys/mman.h>
 #include <errno.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/cio_log.h>
 
 /*


### PR DESCRIPTION
Previously, chunkio exposed functions and macros in chunk_compat.h
as part of library interface. This caused a number of issues in the
downstream source code (e.g. conflicts of macro definitions).

This patch prevents the compatibility header from leaking to the
outer world, while keeping the source tree compilable.

Part of https://github.com/fluent/fluent-bit/issues/960