### PR TITLE
compat: accumulate platform dependent headers

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -64,6 +64,9 @@ inline int getpagesize(void)
 }
 #else
 #include <unistd.h>
+#include <libgen.h>
+#include <dirent.h>
+#include <arpa/inet.h>
 #endif
 
 #endif

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
-#include <arpa/inet.h>
 #include <limits.h>
 
 #include <chunkio/chunkio_compat.h>

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -24,9 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#ifndef _WIN32
-#  include <libgen.h>
-#endif
 
 #include <chunkio/chunkio_compat.h>
 

--- a/src/cio_scan.c
+++ b/src/cio_scan.c
@@ -21,9 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <dirent.h>
-#include <arpa/inet.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_stream.h>
 #include <chunkio/cio_file.h>


### PR DESCRIPTION
Instead of adding ifdefs to each source file, we can aggregate the
non-portable headers in the compat header.

This patch accumulate libgen.h, dirent.h and arpa/inet.h, which are
not available on Windows.

Part of fluent/fluent-bit/issues/960