### PR TITLE
scan: stub out cio_scan_streams() if file system backend is disabled

### DIFF
--- a/src/cio_scan.c
+++ b/src/cio_scan.c
@@ -31,6 +31,7 @@
 #include <chunkio/cio_chunk.h>
 #include <chunkio/cio_log.h>
 
+#ifdef CIO_HAVE_BACKEND_FILESYSTEM
 static int cio_scan_stream_files(struct cio_ctx *ctx, struct cio_stream *st)
 {
     int len;
@@ -119,6 +120,13 @@ int cio_scan_streams(struct cio_ctx *ctx)
     closedir(dir);
     return 0;
 }
+#else
+int cio_scan_streams(struct cio_ctx *ctx)
+{
+    cio_log_error(ctx, "[cio scan] file system backend not supported");
+    return -1;
+}
+#endif
 
 void cio_scan_dump(struct cio_ctx *ctx)
 {


### PR DESCRIPTION
cio_scan_stream() is essentially a function to read chunks from file
storage, and heavily relies on non-portable file system functions
(namely dirent.h).

We need to mock this function out in order to compile the source tree
on platforms without file system backend (i.e. Windows).

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>