### PR TITLE
os: include <sys/types.h> for mode_t

### DIFF
--- a/include/chunkio/cio_os.h
+++ b/include/chunkio/cio_os.h
@@ -19,6 +19,7 @@
 
 #ifndef CIO_OS_H
 #define CIO_OS_H
+#include <sys/types.h>
 
 int cio_os_isdir(const char *dir);
 int cio_os_mkpath(const char *dir, mode_t mode);


### PR DESCRIPTION
We need this in order to compile the source code on Alpine 3.8.2.

Since mode_t is defined in <sys/types.h> on UNIX systems, we need
to include the header before using it.

Should fix the issue fluent/fluent-bit/issues/1011