### PR TITLE
Include <chunkio_compat.h> in each source file

### DIFF
--- a/src/cio_file_compat.c
+++ b/src/cio_file_compat.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_chunk.h>
 #include <chunkio/cio_file_st.h>

--- a/src/cio_meta.c
+++ b/src/cio_meta.c
@@ -21,6 +21,7 @@
 #include <sys/mman.h>
 #include <string.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_file.h>
 #include <chunkio/cio_file_st.h>


### PR DESCRIPTION
These are trivial patches that just place the compat header in source files.

45cdc5e meta: include <chunkio_compat.h> explicitly
7a8d422 file_compat: include <chunkio_compat.h> explicitly

Part of fluent/fluent-bit/issues/960