### PR TITLE
utils: use fread(3) to read the content of file into memory buffer

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -428,7 +428,7 @@ static void cb_cmd_perf(struct cio_ctx *ctx, int opt_buffer, char *pfile,
 
     /* Release file data and destroy context */
     free(carr);
-    munmap(in_data, in_size);
+    free(in_data);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The basic idea is that we can make `cio_utils_read_file()` usable on
Windows by replacing mmap with fread/calloc.

NOTE: Since the function doesn't rely on mmap anymore, the caller
must call free (instead of munmap) to reclaim the memory. This
patch also takes care of it.

Part of fluent/fluent-bit/issues/960