### PR TITLE
tools: disable ANSI color escapes on Windows

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -34,23 +34,34 @@
 #  include <mach/mach.h>
 #endif
 
-#define ANSI_RESET "\033[0m"
-#define ANSI_BOLD  "\033[1m"
+#ifndef _MSC_VER
+#define ANSI_RESET    "\033[0m"
+#define ANSI_BOLD     "\033[1m"
+#define ANSI_CYAN     "\033[96m"
+#define ANSI_MAGENTA  "\033[95m"
+#define ANSI_RED      "\033[91m"
+#define ANSI_YELLOW   "\033[93m"
+#define ANSI_BLUE     "\033[94m"
+#define ANSI_GREEN    "\033[92m"
+#define ANSI_WHITE    "\033[97m"
+#else
+#define ANSI_RESET    ""
+#define ANSI_BOLD     ""
+#define ANSI_CYAN     ""
+#define ANSI_MAGENTA  ""
+#define ANSI_RED      ""
+#define ANSI_YELLOW   ""
+#define ANSI_BLUE     ""
+#define ANSI_GREEN    ""
+#define ANSI_WHITE    ""
+#endif
 
-#define ANSI_CYAN          "\033[96m"
 #define ANSI_BOLD_CYAN     ANSI_BOLD ANSI_CYAN
-#define ANSI_MAGENTA       "\033[95m"
 #define ANSI_BOLD_MAGENTA  ANSI_BOLD ANSI_MAGENTA
-#define ANSI_RED           "\033[91m"
 #define ANSI_BOLD_RED      ANSI_BOLD ANSI_RED
-#define ANSI_YELLOW        "\033[93m"
-
 #define ANSI_BOLD_YELLOW   ANSI_BOLD ANSI_YELLOW
-#define ANSI_BLUE          "\033[94m"
 #define ANSI_BOLD_BLUE     ANSI_BOLD ANSI_BLUE
-#define ANSI_GREEN         "\033[92m"
 #define ANSI_BOLD_GREEN    ANSI_BOLD ANSI_GREEN
-#define ANSI_WHITE         "\033[97m"
 #define ANSI_BOLD_WHITE    ANSI_BOLD ANSI_WHITE
 
 #define CIO_ROOT_PATH  ".cio"


### PR DESCRIPTION
Since most Windows consoles do not understand ANSI escapes, we need
to disable it to prevent the output from being corrupted.

Note: This is essentially the same change set with monkey/monkey/pull/289.

Part of fluent/fluent-bit/issues/960