### PR TITLE
utils: stub out cio_utils_recursive_delete() on Windows

### DIFF
--- a/src/cio_utils.c
+++ b/src/cio_utils.c
@@ -33,6 +33,7 @@
 #include <chunkio/chunkio_compat.h>
 #include <chunkio/cio_log.h>
 
+#ifndef _MSC_VER
 /*
  * Taken from StackOverflow:
  *
@@ -93,6 +94,12 @@ int cio_utils_recursive_delete(const char *dir)
 
     return ret;
 }
+#else
+int cio_utils_recursive_delete(const char *dir)
+{
+    return -1;
+}
+#endif
 
 int cio_utils_read_file(const char *path, char **buf, size_t *size)
 {


### PR DESCRIPTION
We do not need to compile this function on MSVC, since Windows does
not have the filesystem backend support yet.

In future, when we add the filesytem support to Windows, we'll need
to implement the functionality using Win32 API.

Part of fluent/fluent-bit/issues/960