### PR TITLE
utils: do not include headers if not necessary

### DIFF
--- a/src/cio_utils.c
+++ b/src/cio_utils.c
@@ -24,11 +24,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fts.h>
-#include <sys/mman.h>
 #include <errno.h>
+#ifndef _MSC_VER
+#include <fts.h>
+#endif
 
 #include <chunkio/chunkio_compat.h>
 #include <chunkio/cio_log.h>


### PR DESCRIPTION
This patch allows us to compile `cio_utils.c` on Windows without
"no such header file found" errors.

This patch needs merging after #25 and #28.

Part of fluent/fluent-bit/issues/960