### PR TITLE
tools: cio: mock out cio_default_root_path on Windows

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -23,12 +23,12 @@
 #include <getopt.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/mman.h>
-#include <sys/time.h>
-#include <pwd.h>
 #include <limits.h>
 #include <signal.h>
 #include <time.h>
+#ifndef _MSC_VER
+#include <pwd.h>
+#endif
 #ifdef __MACH__
 #  include <mach/clock.h>
 #  include <mach/mach.h>
@@ -192,6 +192,7 @@ static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
     return 0;
 }
 
+#ifndef _MSC_VER
 static int cio_default_root_path(char *path, int size)
 {
     int len;
@@ -213,6 +214,12 @@ static int cio_default_root_path(char *path, int size)
 
     return 0;
 }
+#else
+static int cio_default_root_path(char *path, int size)
+{
+    return -1;
+}
+#endif
 
 static void cio_timespec_get(struct timespec *t)
 {


### PR DESCRIPTION
We don't need this function for now since Windows does not have
the file system support yet.

In future, we'll need to implement getpwuid() using Win32 API,
in order to get an equivalent path on Windows.

Part of fluent/fluent-bit/issues/960