### PR TITLE
tools: cio: add _MSC_VER ifdefs to POSIX signals

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -113,8 +113,10 @@ static void cio_signal_handler(int signal)
     write(STDERR_FILENO, s, sizeof(s) - 1);
     switch (signal) {
         cio_print_signal(SIGINT);
+#ifndef _MSC_VER
         cio_print_signal(SIGQUIT);
         cio_print_signal(SIGHUP);
+#endif
         cio_print_signal(SIGTERM);
         cio_print_signal(SIGSEGV);
     };
@@ -122,8 +124,10 @@ static void cio_signal_handler(int signal)
     /* Signal handlers */
     switch (signal) {
     case SIGINT:
+#ifndef _MSC_VER
     case SIGQUIT:
     case SIGHUP:
+#endif
     case SIGTERM:
         _exit(EXIT_SUCCESS);
     case SIGSEGV:
@@ -161,8 +165,10 @@ void cio_bytes_to_human_readable_size(size_t bytes,
 static void cio_signal_init()
 {
     signal(SIGINT,  &cio_signal_handler);
+#ifndef _MSC_VER
     signal(SIGQUIT, &cio_signal_handler);
     signal(SIGHUP,  &cio_signal_handler);
+#endif
     signal(SIGTERM, &cio_signal_handler);
     signal(SIGSEGV, &cio_signal_handler);
 }


### PR DESCRIPTION
MSVC only supports a handful of signals, and we do not have SIGHUP
and SIGQUIT on that platform.

This adds ifdefs macros so that we can compile the code on Windows.

Part of fluent/fluent-bit/issues/960