### PR TITLE
tools: use uint64_t to avoid integer overflow

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -137,7 +137,7 @@ void cio_bytes_to_human_readable_size(size_t bytes,
                                       char *out_buf, size_t size)
 {
     unsigned long i;
-    unsigned long u = 1024;
+    uint64_t u = 1024;
     static const char *__units[] = {
         "b", "K", "M", "G",
         "T", "P", "E", "Z", "Y", NULL


### PR DESCRIPTION
On Windows, where "long" is just 32-bit in length, the unit variable
can overflow if the input number is sufficiently large.

This patch fixes the bug by explicitly using a 64-bit integer.

Part of fluent/fluent-bit/issues/960