### PR TITLE
tools: make main() always return an integer value

### DIFF
--- a/tools/cio.c
+++ b/tools/cio.c
@@ -444,7 +444,7 @@ static void cb_cmd_perf(struct cio_ctx *ctx, int opt_buffer, char *pfile,
 
 int main(int argc, char **argv)
 {
-    int ret;
+    int ret = 0;
     int opt;
     int opt_silent = CIO_FALSE;
     int opt_pwrites = 5;


### PR DESCRIPTION
Previously main() sometimes return `ret` without initializing it,
which has been causing runtime errors on Windows.

This patch resolves the bug by initializing the variable to zero.

Part of fluent/fluent-bit/issues/960