### PR TITLE
compat: add missing "static" declaration for getpagesize()

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -56,7 +56,7 @@ static inline char* dirname(const char *path)
     return buf;
 }
 
-inline int getpagesize(void)
+static inline int getpagesize(void)
 {
     SYSTEM_INFO system_info;
     GetSystemInfo(&system_info);


### PR DESCRIPTION
We need this in order to avoid conflict of functions symbols
in the downstream programs.

Part of fluent/fluent-bit/issues/960