### PR TITLE
build: turn off CIO_BACKEND_FILESYSTEM on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ option(CIO_SANITIZE_ADDRESS  "Enable address sanitizer"     Off)
 option(CIO_TESTS             "Enable tests"                 Off)
 option(CIO_BACKEND_FILESYSTEM "Enable filesystem backend"   On)
 
+# Windows does not have file system backend support yet.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(CIO_BACKEND_FILESYSTEM Off)
+endif()
+
 # Force Option value
 macro(CIO_OPTION option value)
   set(${option} ${value} CACHE "" INTERNAL FORCE)


### PR DESCRIPTION
... so that we can build chunkio on Windows just by:

    $ cd build
    $ cmake ..
    $ make

Without this, we need to not forget to add a special option
-DCIO_BACKEND_FILESYSTEMA=Off to the second line.

Part of fluent/fluent-bit/issues/960