### PR TITLE
file: make chunkio compilable again on Windows

### DIFF
--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -46,7 +46,6 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
                                int flags,
                                size_t size);
 void cio_file_close(struct cio_chunk *ch, int delete);
-int cio_file_unmap(struct cio_chunk *ch);
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);

--- a/src/cio_file_compat.c
+++ b/src/cio_file_compat.c
@@ -17,6 +17,14 @@
  *  limitations under the License.
  */
 
+/*
+ * Trivial stub implementation of cio_file.h.
+ *
+ * If your C runtime doesn't offer enough functionality to compile
+ * cio_file.c, you can compile and link this file instead. See
+ * CIO_BACKEND_FILESYSTEM in chunkio/CMakeList.txt for details.
+ */
+
 #include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_chunk.h>
@@ -83,6 +91,21 @@ void cio_file_scan_dump(struct cio_ctx *ctx, struct cio_stream *st)
 }
 
 int cio_file_read_prepare(struct cio_ctx *ctx, struct cio_chunk *ch)
+{
+    return -1;
+}
+
+int cio_file_is_up(struct cio_chunk *ch, struct cio_file *cf)
+{
+    return CIO_FALSE;
+}
+
+int cio_file_down(struct cio_chunk *ch)
+{
+    return -1;
+}
+
+int cio_file_up(struct cio_chunk *ch)
 {
     return -1;
 }


### PR DESCRIPTION
The following file function interfaces were added in 349752a.

 - cio_file_up()
 - cio_file_down()
 - cio_file_is_up()

This patch adds corresponding implementations to cio_file_compat.h.
The main effect of this patch is getting chunkio compilable on Windows.

Also I cleaned up a non-existing function from cio_file.h in 5b755d1,
in order to make every bit in sync perfectly.