### PR TITLE
Add trace level log

### DIFF
--- a/include/chunkio/chunkio.h
+++ b/include/chunkio/chunkio.h
@@ -30,6 +30,7 @@
 #define CIO_WARN   2
 #define CIO_INFO   3
 #define CIO_DEBUG  4
+#define CIO_TRACE  5
 
 /* Storage backend */
 #define CIO_STORE_FS        0

--- a/include/chunkio/cio_log.h
+++ b/include/chunkio/cio_log.h
@@ -44,6 +44,10 @@ int cio_errno_print(int errnum, const char *file, int line);
     cio_log_print(ctx, CIO_DEBUG, __FILENAME__,     \
                   __LINE__, fmt, ##__VA_ARGS__)
 
+#define cio_log_trace(ctx, fmt, ...)                \
+    cio_log_print(ctx, CIO_trace, __FILENAME__,     \
+                  __LINE__, fmt, ##__VA_ARGS__)
+
 #ifdef __FILENAME__
 #define cio_errno() cio_errno_print(errno, __FILENAME__, __LINE__)
 #else

--- a/src/chunkio.c
+++ b/src/chunkio.c
@@ -59,7 +59,7 @@ struct cio_ctx *cio_create(const char *root_path,
     int ret;
     struct cio_ctx *ctx;
 
-    if (log_level < CIO_ERROR || log_level > CIO_DEBUG) {
+    if (log_level < CIO_ERROR || log_level > CIO_TRACE) {
         fprintf(stderr, "[cio] invalid log level, aborting");
         return NULL;
     }
@@ -131,7 +131,7 @@ void cio_set_log_callback(struct cio_ctx *ctx, void (*log_cb))
 
 int cio_set_log_level(struct cio_ctx *ctx, int level)
 {
-    if (level < CIO_ERROR || level > CIO_DEBUG) {
+    if (level < CIO_ERROR || level > CIO_TRACE) {
         return -1;
     }
 

--- a/tests/context.c
+++ b/tests/context.c
@@ -117,7 +117,15 @@ static void test_log_level()
     /* Test: CIO_DEBUG */
     cio_set_log_level(ctx, CIO_DEBUG);
     log_check = 0;
+    cio_log_trace(ctx, "test");
+    TEST_CHECK(log_check == 0);
     cio_log_debug(ctx, "test");
+    TEST_CHECK(log_check == 1);
+
+    /* Test: CIO_TRACE */
+    cio_set_log_level(ctx, CIO_TRACE);
+    log_check = 0;
+    cio_log_trace(ctx, "test");
     TEST_CHECK(log_check == 1);
 
     /* destroy context */


### PR DESCRIPTION
I added a trace level to logger.

I encountered the following error  when I tried [README example about cio]( https://github.com/edsiper/chunkio/blob/f68c66364a4ee87723203ac09ea2580681e21b53/README.md#cio---client-tool).

```
$ cat ./CMakeCache.txt | tools/cio -i -s stdin -f somefile -vvv                                                                                    
[cio] invalid log level, aborting
```
I found it was caused by [this commit](https://github.com/edsiper/chunkio/commit/24791539a498aa8d6ce22d678d679618c859d8ef#diff-c7299ab194b49468d1a3b7c86599d91cR397).  and I also found cio didn't have trace log level.
If you don't like adding trace level, I will change this PR to removing `v` from `-vvv` in README.

@edsiper what do you think of this pr?
