### PR TITLE
stats: make it compatible with Windows

### DIFF
--- a/src/cio_stats.c
+++ b/src/cio_stats.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <chunkio/chunkio_compat.h>
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_chunk.h>
 #include <chunkio/cio_stats.h>


### PR DESCRIPTION
This is a simple fix to make cio_stats.c compilable on Windows.
In short, it needs chunkio_compat.h to load a chain of Windows-
specific headers.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>