### PR TITLE
file_compat: add stub function for cio_file_is_up()

### DIFF
--- a/src/cio_file_compat.c
+++ b/src/cio_file_compat.c
@@ -109,3 +109,8 @@ int cio_file_up(struct cio_chunk *ch)
 {
     return -1;
 }
+
+int cio_file_is_up(struct cio_chunk *ch, struct cio_file *cf)
+{
+    return -1;
+}


### PR DESCRIPTION
Without this, VisualStudio would fail to compile it with an error
"unresolved externals". Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>