### PR TITLE
file_compat: add stub function for cio_file_up_force()

### DIFF
--- a/src/cio_file_compat.c
+++ b/src/cio_file_compat.c
@@ -109,3 +109,8 @@ int cio_file_up(struct cio_chunk *ch)
 {
     return -1;
 }
+
+int cio_file_up_force(struct cio_chunk *ch)
+{
+    return -1;
+}


### PR DESCRIPTION
We need this in order to compile the module on Windows without an
error about unresolved symbols.

This should bring chunkio to Windows-ready again.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>