### PR TITLE
file: cmake check for fallocate availability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,20 @@ if(CIO_BACKEND_FILESYSTEM)
   CIO_DEFINITION(CIO_HAVE_BACKEND_FILESYSTEM)
 endif()
 
+include(CheckCSourceCompiles)
+
+# fallocate support
+check_c_source_compiles("
+  #include <fcntl.h>
+  int main() {
+     fallocate(0,0,0);
+     return 0;
+  }" CIO_HAVE_FALLOCATE)
+
+if(CIO_HAVE_FALLOCATE)
+  CIO_DEFINITION(CIO_HAVE_FALLOCATE)
+endif()
+
 include_directories(
   include
   deps/

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -962,7 +962,7 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
 
     /* macOS does not have fallocate().
      * So, we should use ftruncate always. */
-#ifdef __linux__
+#if defined(CIO_HAVE_FALLOCATE)
     if (new_size > cf->alloc_size) {
         /*
          * To increase the file size we use fallocate() since this option


### PR DESCRIPTION
(via [fluent-bit](https://github.com/fluent/fluent-bit/pull/1452))

Some versions of uClibc don't have fallocate, eventhough Linux of a sort.

This change adds a cmake check for fallocate.