### PR TITLE
CIO_FALSE is right

### DIFF
--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -357,7 +357,7 @@ int cio_chunk_tx_rollback(struct cio_chunk *ch)
     struct cio_memfs *mf;
     struct cio_file *cf;
 
-    if (ch->tx_active == CIO_TRUE) {
+    if (ch->tx_active == CIO_FALSE) {
         return -1;
     }
 


### PR DESCRIPTION
Because `tx_active` is set `CIO_TRUE` in cio_chunk_tx_begin
https://github.com/edsiper/chunkio/blob/19d8f5ad7e13fd0491175157867be94002eceed2/src/cio_chunk.c#L319