### PR TITLE
meta size

### DIFF
--- a/include/chunkio/chunkio.h
+++ b/include/chunkio/chunkio.h
@@ -82,6 +82,7 @@ int cio_set_max_chunks_up(struct cio_ctx *ctx, int n);
 int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size);
 int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);
 int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len);
+int cio_meta_size(struct cio_chunk *ch);
 
 ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
 

--- a/include/chunkio/cio_meta.h
+++ b/include/chunkio/cio_meta.h
@@ -26,5 +26,6 @@
 int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size);
 int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len);
 int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);
+int cio_meta_size(struct cio_chunk *ch);
 
 #endif

--- a/src/cio_meta.c
+++ b/src/cio_meta.c
@@ -72,6 +72,19 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
     return -1;
 }
 
+int cio_meta_size(struct cio_chunk *ch) {
+    if (ch->st->type == CIO_STORE_MEM) {
+        struct cio_memfs *mf = (struct cio_memfs *) ch->backend;
+        return mf->meta_len;
+    }
+    else if (ch->st->type == CIO_STORE_FS) {
+        struct cio_file *cf = ch->backend;
+        return cio_file_st_get_meta_len(cf->map);
+    }
+
+    return -1;
+}
+
 int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
 {
     int len;


### PR DESCRIPTION
I added a method `cio_meta_size` to get the size of a metdata.
Present implementation can't get the size of a metedata and cio_meta_read returns `-1` if metadata size is 0. so I need this method to identify that metadata is invalid or zero size.


