### PR TITLE
add cio_chunk_unlink

### DIFF
--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -41,6 +41,7 @@ struct cio_chunk {
 struct cio_chunk *cio_chunk_open(struct cio_ctx *ctx, struct cio_stream *st,
                                  const char *name, int flags, size_t size);
 void cio_chunk_close(struct cio_chunk *ch, int delete);
+int cio_chunk_unlink(struct cio_chunk *ch);
 int cio_chunk_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_chunk_write_at(struct cio_chunk *ch, off_t offset,
                        const void *buf, size_t count);

--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -46,6 +46,7 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
                                int flags,
                                size_t size);
 void cio_file_close(struct cio_chunk *ch, int delete);
+int cio_file_unlink(struct cio_chunk *ch);
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -112,6 +112,18 @@ void cio_chunk_close(struct cio_chunk *ch, int delete)
     free(ch);
 }
 
+int cio_chunk_unlink(struct cio_chunk *ch)
+{
+    int type;
+
+    type = ch->st->type;
+    if (type == CIO_STORE_FS) {
+        return cio_file_unlink(ch);
+    }
+
+    return 0;
+}
+
 /*
  * Write at a specific offset of the content area. Offset must be >= 0 and
  * less than current data length.

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -642,7 +642,6 @@ int cio_file_down(struct cio_chunk *ch)
 
 void cio_file_close(struct cio_chunk *ch, int delete)
 {
-    int ret;
     struct cio_file *cf = (struct cio_file *) ch->backend;
 
     if (!cf) {
@@ -654,13 +653,7 @@ void cio_file_close(struct cio_chunk *ch, int delete)
 
     /* Should we delete the content from the file system ? */
     if (delete == CIO_TRUE) {
-        ret = unlink(cf->path);
-        if (ret == -1) {
-            cio_errno();
-            cio_log_error(ch->ctx,
-                          "[cio file] error deleting file at close %s:%s",
-                          ch->st->name, ch->name);
-        }
+        cio_file_unlink(ch);          /* ignore return value */
     }
 
     /* Close file descriptor */
@@ -670,6 +663,21 @@ void cio_file_close(struct cio_chunk *ch, int delete)
 
     free(cf->path);
     free(cf);
+}
+
+int cio_file_unlink(struct cio_chunk *ch)
+{
+    int ret;
+    struct cio_file *cf = (struct cio_file *) ch->backend;
+
+    ret = unlink(cf->path);
+    if (ret == -1) {
+        cio_errno();
+        cio_log_error(ch->ctx,
+                      "[cio file] error deleting file at close %s:%s",
+                      ch->st->name, ch->name);
+    }
+    return ret;
 }
 
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count)


### PR DESCRIPTION
I'd like to divide the timing of `unlink` the file between freeing the chunk object.
e.g. https://github.com/ganmacs/chunkio-rb/blob/02671efff5a012da2a74ba5ec31a86482d8a4014/ext/chunkio/chunkio_chunk.c#L35

