### PR TITLE
ensure call cio_file_close in mmap_file to avoid double free

### DIFF
--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -342,7 +342,7 @@ static int mmap_file(struct cio_ctx *ctx, struct cio_chunk *ch, size_t size)
     if (ret == -1) {
         cio_log_error(ctx, "format check failed: %s/%s",
                       ch->st->name, ch->name);
-        munmap_file(ctx, ch);
+        cio_file_close(ch, CIO_FALSE);
         return -1;
     }
 
@@ -522,7 +522,6 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
     /* Map the file */
     ret = mmap_file(ctx, ch, size);
     if (ret == -1) {
-        cio_file_close(ch, CIO_FALSE);
         return NULL;
     }
 


### PR DESCRIPTION
Current implementation occurs the following error when loading file is an invalid format.
this cause is calling `cio_file_close` twice at and
https://github.com/edsiper/chunkio/blob/1452f4175d808a855c80d3f93ae83383a4b8cd90/src/cio_file.c#L330
and
https://github.com/edsiper/chunkio/blob/1452f4175d808a855c80d3f93ae83383a4b8cd90/src/cio_file.c#L525

```
cio(86087,0x1054265c0) malloc: *** error for object 0x7fea3ac02d60: pointer being freed was not allocated
cio(86087,0x1054265c0) malloc: *** set a breakpoint in malloc_error_break to debug
```

minimal reproduction code


```c
    struct cio_ctx *ctx;
    struct cio_stream *stream;
    ctx = cio_create("tmp", 0, CIO_DEBUG, 0);
    stream = cio_stream_create(ctx, "test", CIO_STORE_FS);
    cio_chunk_open(ctx, stream, "c", CIO_OPEN, 1000);
```

tmp/test/c
```
{}
```


