### PR TITLE
file_compat: add stub function for cio_file_copy_content()

### DIFF
--- a/src/cio_file_compat.c
+++ b/src/cio_file_compat.c
@@ -95,6 +95,12 @@ int cio_file_read_prepare(struct cio_ctx *ctx, struct cio_chunk *ch)
     return -1;
 }
 
+int cio_file_content_copy(struct cio_chunk *ch,
+                          void **out_buf, size_t *out_size)
+{
+    return -1;
+}
+
 int cio_file_is_up(struct cio_chunk *ch, struct cio_file *cf)
 {
     return CIO_FALSE;


### PR DESCRIPTION
Without this, we cannot link chunkio on Windows.

    unresolved external symbol cio_file_content_copy

Resolve this issue by adding a compatibility shim function.

Note: This commit is required to compile Fuent Bit v1.6.0.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>