### PR TITLE
tests: context: CIO_TRACE (5) is a valid debug level

### DIFF
--- a/tests/context.c
+++ b/tests/context.c
@@ -53,8 +53,8 @@ static void test_context()
     ctx = cio_create("/tmp/", NULL, -1, flags);
     TEST_CHECK(ctx == NULL);
 
-    /* Invalid debug level 5 */
-    ctx = cio_create("/tmp/", NULL, 5, flags);
+    /* Invalid debug level 6 */
+    ctx = cio_create("/tmp/", NULL, 6, flags);
     TEST_CHECK(ctx == NULL);
 
     /* Valid context without callback */


### PR DESCRIPTION
Contrary to the description, passing 5 to `log_level` parameter is
actually valid (which means TRACE level).

We needed to pass an integer larger than 5 to cause cio_create()
to fail.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>