### PR TITLE
os: Use SHCreateDirectoryEx() for create folders

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -25,6 +25,7 @@
 #include <windows.h>
 #include <io.h>
 #include <direct.h>
+#include <shlobj_core.h>
 #pragma comment(lib, "ws2_32.lib")
 
 /** mode flags for access() */

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -60,6 +60,12 @@ int cio_os_mkpath(const char *dir, mode_t mode)
         return 0;
     }
 
+#ifdef _WIN32
+    if (SHCreateDirectoryExA(NULL, dir, NULL) != ERROR_SUCCESS) {
+        return 1;
+    }
+    return 0;
+#else
     dup_dir = strdup(dir);
     if (!dup_dir) {
         return 1;
@@ -67,4 +73,5 @@ int cio_os_mkpath(const char *dir, mode_t mode)
     cio_os_mkpath(dirname(dup_dir), mode);
     free(dup_dir);
     return mkdir(dir, mode);
+#endif
 }


### PR DESCRIPTION
`SHCreateDirectoryEx()` is recursive i.e. it transparently creates
intermediate folders if not exist.

Use this function on Windows instead of manually calling `mkdir()`
multiple times.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>