### PR TITLE
core: Remove a duplicated declaration of cio_chunk_get_real_size()

### DIFF
--- a/include/chunkio/chunkio.h
+++ b/include/chunkio/chunkio.h
@@ -84,6 +84,4 @@ int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);
 int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len);
 int cio_meta_size(struct cio_chunk *ch);
 
-ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
-
 #endif


### PR DESCRIPTION
`cio_chunk_get_real_size()` has two prototype declarations:

 (1) line 70 in chunkio/chunkio.h
 (2) line 50 in chunkio/cio_chunk.h.

This patch removes (1) to avoid duplication.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>