### PR TITLE
file: Remove a non-existent function 'cio_file_close_stream()'

### DIFF
--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -50,7 +50,6 @@ int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);
 int cio_file_fs_size_change(struct cio_file *cf, size_t new_size);
-int cio_file_close_stream(struct cio_stream *st);
 char *cio_file_hash(struct cio_file *cf);
 void cio_file_hash_print(struct cio_file *cf);
 void cio_file_calculate_checksum(struct cio_file *cf, crc_t *out);


### PR DESCRIPTION
`cio_file_close_stream()` is a ghost function that does not have
a corresponding implementation in `cio_file.c`.

This patch removes the declaration from the header file.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>