### PR TITLE
compat: Make dirname() returns "." on filenames

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -53,6 +53,14 @@ static inline char* dirname(const char *path)
 
     _makepath_s(buf, _MAX_PATH, drive, dir, "", "");
 
+    /*
+     * If path does not contain a separator, dirname() must
+     * return the string ".".
+     */
+    if (strlen(buf) == 0) {
+        strcpy(buf, ".");
+    }
+
     return buf;
 }
 


### PR DESCRIPTION
According to dirname(2):

> If path does not contain a slash, dirname() returns the string "."
> while basename() returns a copy of path.

This makes Windows' dirname() emulation behave in the same way.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>