### PR TITLE
core: Add "Shell32.lib" into the dependency list

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     )
   set(libs
     ${libs}
+    Shell32.lib
     Shlwapi.lib)
 else()
   set(src


### PR DESCRIPTION
cio_os.c uses `SHCreateDirectory()` to create directories on Windows.
This particular function is provided by Shell32.lib.

Add the library to the dependency list explicitly to avoid potential
build issues.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>