### PR TITLE
os: include <Shlobj.h> for SHCreateDirectoryExA()

### DIFF
--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -27,6 +27,10 @@
 
 #include <chunkio/chunkio_compat.h>
 
+#ifdef _WIN32
+#include <Shlobj.h>
+#endif
+
 /* Check if a path is a directory */
 int cio_os_isdir(const char *dir)
 {


### PR DESCRIPTION
Add the exact header file that defines the prototype of
`SHCreateDirectoryExA()`.

This patch should fix the following compiler warning:

    warning C4013: 'SHCreateDirectoryExA' undefined;
    assuming extern returning int

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>