### PR TITLE
cio_os: Fix 'unresolved external symbol _SHCreateDirectoryExA' on x86

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     )
   set(libs
     ${libs}
+    Shell32.lib
     Shlwapi.lib)
 else()
   set(src

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -27,6 +27,10 @@
 
 #include <chunkio/chunkio_compat.h>
 
+#ifdef _WIN32
+#include <Shlobj.h>
+#endif
+
 /* Check if a path is a directory */
 int cio_os_isdir(const char *dir)
 {


### PR DESCRIPTION
Sophie Fang found that x86 Windows build fails with the following
error:

    error LNK2001: unresolved external symbol _SHCreateDirectoryExA

After investigation, it turned out that this was caused by a missing
header file in `cio_os.h`, and can be simply fixed by adding one.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>