### PR TITLE
Fix CRC32 in the initialization header

### DIFF
--- a/src/cio_file_win32.c
+++ b/src/cio_file_win32.c
@@ -59,7 +59,7 @@ static char init_bytes[] = {
     CIO_FILE_ID_00, CIO_FILE_ID_01,
 
     /* crc32 (4 bytes) in network byte order */
-    0xff, 0x12, 0xd9, 0x41,
+    0x41, 0xd9, 0x12, 0xff,
 
     /* padding bytes (we have 16 extra bytes */
     0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
The definition was copied verbatim from src/cio_file.c, but it
turned out that the byte order was wrong.

We can confirm this by testing the following with Python:

```python
>>> import binascii, struct
>>> binascii.crc32(b"\0" * 2)
1104745215
>>> struct.pack(">I", 1104745215) # network order
b'A\xd9\x12\xff'
```

So the initial bytes should be the following

```python
{0x41, 0xd9, 0x12, 0xff}
```

not:

```python
{0xff, 0x12, 0xd9, 0x41}
```
Fix the definition thusly.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>