### PR TITLE
Address issue of falures on ext3 and reiserfs filesystems

### DIFF
--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -1049,6 +1049,13 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
          * fallocate() is not portable, Linux only.
          */
         ret = fallocate(cf->fd, 0, 0, new_size);
+        if (ret == EOPNOTSUPP) {
+            /* If fallocate fails with an EOPNOTSUPP try operation using
+             * posix_fallocate. Required since some filesystems do not support
+             * the fallocate operation e.g. ext3 and reiserfs.
+             */
+            ret = posix_fallocate(cf->fd, 0, new_size);
+        }
     }
     else
 #endif


### PR DESCRIPTION
The fallocate operation is failing on e.g. ext3 and reiserf filesystems.
By falling back to use posix_fallocate if the fallocate function call fails
one can keep the performance as is for fallocate supported filesystems but
still support legacy filesystems as ext3 and reiserfs.

This would resolve issue: https://github.com/edsiper/chunkio/issues/46
