### PR TITLE
Handle fallocate errors on legacy linuxes

### DIFF
--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -1049,10 +1049,10 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
          * fallocate() is not portable, Linux only.
          */
         ret = fallocate(cf->fd, 0, 0, new_size);
-        if (ret == EOPNOTSUPP) {
-            /* If fallocate fails with an EOPNOTSUPP try operation using
-             * posix_fallocate. Required since some filesystems do not support
-             * the fallocate operation e.g. ext3 and reiserfs.
+        if (ret != 0) {
+            /* If fallocate fails with an non zero return code  try operation
+             * using posix_fallocate. Required since some filesystems do not
+             * support the fallocate operation e.g. ext3 and reiserfs.
              */
             ret = posix_fallocate(cf->fd, 0, new_size);
         }


### PR DESCRIPTION
Older linuxes as e.g. SLES 11 SP4 does not return EOPNOTSUPP for not supported
filesystem. Instead it returns the generic -1 failure and sets the errno with
description Operation not supported. This fix does instead check if the
operation failes with a non zero return value and in such cases revert to
posix_fallocate. Other errors as e.g. ENOSPC will hence rely to be returned by
the call to posix_fallocate.

Signed-off-by: sirwio <sirwio@hotmail.com>