### PR TITLE
file: win32: do not emit error messages on 'max_chunks_up'

### DIFF
--- a/src/cio_file_win32.c
+++ b/src/cio_file_win32.c
@@ -788,7 +788,6 @@ int cio_file_up(struct cio_chunk *ch)
     }
 
     if (count_open_file_chunks(ch->ctx) >= ch->ctx->max_chunks_up) {
-        win32_chunk_error(ch, "[cio file] too many open chunks");
         return -1;
     }
     return cio_file_up_force(ch);


### PR DESCRIPTION
This message turns out to be confusing, as Fluent Bit keeps emitting
this message when it hits `max_chunks_up` while processing a large
amount logs.

The same code for Linux/BSD (cio_file.c:497) emits nothing in this
particular failure path. Let's be silent on Windows as well.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>