### PR TITLE
chunk file size improvement

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -21,6 +21,8 @@
 #define CHUNKIO_COMPAT_H
 
 #ifdef _WIN32
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <winsock2.h>
 #include <windows.h>
 #include <io.h>

--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -44,6 +44,7 @@ struct cio_file {
     crc_t crc_cur;
 };
 
+size_t cio_file_real_size(struct cio_file *cf);
 struct cio_file *cio_file_open(struct cio_ctx *ctx,
                                struct cio_stream *st,
                                struct cio_chunk *ch,

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -286,6 +286,12 @@ ssize_t cio_chunk_get_real_size(struct cio_chunk *ch)
     }
     else if (type == CIO_STORE_FS) {
         cf = ch->backend;
+
+        /* If the file is not open we need to explicitly get its size */
+        if (cf->fs_size == 0) {
+            return cio_file_real_size(cf);
+        }
+
         return cf->fs_size;
     }
 

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -1095,6 +1095,10 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
         ret = ftruncate(cf->fd, new_size);
     }
 
+    if (!ret) {
+        cf->fs_size = new_size;
+    }
+
     return ret;
 }
 

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -508,6 +508,24 @@ static inline int open_and_up(struct cio_ctx *ctx)
 }
 
 /*
+ * Fetch the file size regardless of if we opened this file or not.
+ */
+size_t cio_file_real_size(struct cio_file *cf)
+{
+    int ret;
+    struct stat st;
+
+    /* Store the current real size */
+    ret = stat(cf->path, &st);
+    if (ret == -1) {
+        cio_errno();
+        return 0;
+    }
+
+    return st.st_size;
+}
+
+/*
  * Open or create a data file: the following behavior is expected depending
  * of the passed flags:
  *

--- a/src/cio_file_win32.c
+++ b/src/cio_file_win32.c
@@ -330,6 +330,33 @@ static int is_valid_file_name(const char *name)
 }
 
 /*
+ * Fetch the file size regardless of if we opened this file or not.
+ */
+size_t cio_file_real_size(struct cio_file *cf)
+{
+    int ret;
+#ifdef _WIN64
+    struct __stat64 st;
+#else
+    struct _wstat32 st;
+#endif
+
+    /* Store the current real size */
+#ifdef _WIN64
+    ret = _wstat64(cf->path, &st);
+#else
+    ret = _wstat32(cf->path, &st);
+#endif
+
+    if (ret != 0) {
+        cio_errno();
+        return 0;
+    }
+
+    return st.st_size;
+}
+
+/*
  * Return a new file chunk instance. This is the starting
  * point for manipulating file chunks.
  */


### PR DESCRIPTION
Added a function named `cio_file_real_size` that gets the chunk file size of a chunk
regardless of its state and made `cio_chunk_get_real_size` fall back to it if the value
in the structure is zero.