### PR TITLE
compat: fix collisions with fluent-bit

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -30,19 +30,28 @@
 #pragma comment(lib, "ws2_32.lib")
 
 /** mode flags for access() */
+
+#ifndef R_OK
 #define R_OK 04
 #define W_OK 02
 #define X_OK 01
 #define F_OK 00
+#endif
 
+#ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
+#endif
+
+#ifndef S_ISREG
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
-#define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
+#endif
 
-typedef SSIZE_T ssize_t;
-typedef unsigned mode_t;
+#define cio_strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 
-static inline char* dirname(const char *path)
+typedef SSIZE_T  cio_ssize_t;
+typedef unsigned cio_mode_t;
+
+static inline char* cio_dirname(const char *path)
 {
     char drive[_MAX_DRIVE];
     char dir[_MAX_DIR];
@@ -66,17 +75,27 @@ static inline char* dirname(const char *path)
     return buf;
 }
 
-static inline int getpagesize(void)
+static inline int cio_getpagesize(void)
 {
     SYSTEM_INFO system_info;
     GetSystemInfo(&system_info);
     return system_info.dwPageSize;
 }
+
 #else
 #include <unistd.h>
 #include <libgen.h>
 #include <dirent.h>
 #include <arpa/inet.h>
+
+#define cio_strerror_r(errno,buf,len) strerror_r(errno,buf,len)
+#define cio_getpagesize() getpagesize()
+#define cio_dirname(path) dirname(path)
+
+typedef ssize_t cio_ssize_t;
+typedef mode_t  cio_mode_t;
+
+
 #endif
 
 #endif

--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -25,6 +25,13 @@
 
 #include <chunkio/chunkio_compat.h>
 
+// #ifdef _WIN32
+// #include <windows.h>
+// typedef SSIZE_T cio_ssize_t;
+// #else
+// typedef ssize_t cio_ssize_t;
+// #endif
+
 struct cio_chunk {
     int lock;                 /* locked for write operations ? */
     char *name;               /* chunk name */
@@ -62,8 +69,8 @@ int cio_chunk_get_content(struct cio_chunk *ch, char **buf, size_t *size);
 int cio_chunk_get_content_copy(struct cio_chunk *ch,
                                void **out_buf, size_t *out_size);
 
-ssize_t cio_chunk_get_content_size(struct cio_chunk *ch);
-ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
+cio_ssize_t cio_chunk_get_content_size(struct cio_chunk *ch);
+cio_ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
 size_t cio_chunk_get_content_end_pos(struct cio_chunk *ch);
 void cio_chunk_close_stream(struct cio_stream *st);
 char *cio_chunk_hash(struct cio_chunk *ch);

--- a/include/chunkio/cio_file_st.h
+++ b/include/chunkio/cio_file_st.h
@@ -23,6 +23,8 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
+#include <chunkio/chunkio_compat.h>
+
 /*
  * ChunkIO data file layout as of 2018/10/26
  *
@@ -94,7 +96,7 @@ static inline char *cio_file_st_get_content(char *map)
     return map + CIO_FILE_HEADER_MIN + len;
 }
 
-static inline ssize_t cio_file_st_get_content_size(char *map, size_t size)
+static inline cio_ssize_t cio_file_st_get_content_size(char *map, size_t size)
 {
     int meta_len;
     size_t s;

--- a/include/chunkio/cio_os.h
+++ b/include/chunkio/cio_os.h
@@ -20,8 +20,9 @@
 #ifndef CIO_OS_H
 #define CIO_OS_H
 #include <sys/types.h>
+#include <chunkio/chunkio_compat.h>
 
 int cio_os_isdir(const char *dir);
-int cio_os_mkpath(const char *dir, mode_t mode);
+int cio_os_mkpath(const char *dir, cio_mode_t mode);
 
 #endif

--- a/src/chunkio.c
+++ b/src/chunkio.c
@@ -87,7 +87,7 @@ struct cio_ctx *cio_create(const char *root_path,
         return NULL;
     }
     mk_list_init(&ctx->streams);
-    ctx->page_size = getpagesize();
+    ctx->page_size = cio_getpagesize();
     ctx->max_chunks_up = CIO_MAX_CHUNKS_UP;
     ctx->flags = flags;
 

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -272,7 +272,7 @@ size_t cio_chunk_get_content_end_pos(struct cio_chunk *ch)
     return pos;
 }
 
-ssize_t cio_chunk_get_content_size(struct cio_chunk *ch)
+cio_ssize_t cio_chunk_get_content_size(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;
@@ -293,7 +293,7 @@ ssize_t cio_chunk_get_content_size(struct cio_chunk *ch)
     return -1;
 }
 
-ssize_t cio_chunk_get_real_size(struct cio_chunk *ch)
+cio_ssize_t cio_chunk_get_real_size(struct cio_chunk *ch)
 {
     int type;
     struct cio_memfs *mf;

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -599,7 +599,7 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
 
     cf->fd = -1;
     cf->flags = flags;
-    cf->realloc_size = getpagesize() * 8;
+    cf->realloc_size = ctx->page_size * 8;
     cf->st_content = NULL;
     cf->crc_cur = cio_crc32_init();
     cf->path = path;

--- a/src/cio_log.c
+++ b/src/cio_log.c
@@ -56,7 +56,7 @@ int cio_errno_print(int errnum, const char *file, int line)
 {
     char buf[256];
 
-    strerror_r(errnum, buf, sizeof(buf) - 1);
+    cio_strerror_r(errnum, buf, sizeof(buf) - 1);
     fprintf(stderr, "[%s:%i errno=%i] %s\n",
             file, line, errnum, buf);
     return 0;

--- a/src/cio_memfs.c
+++ b/src/cio_memfs.c
@@ -48,7 +48,7 @@ struct cio_memfs *cio_memfs_open(struct cio_ctx *ctx, struct cio_stream *st,
     }
     mf->buf_size = size;
     mf->buf_len = 0;
-    mf->realloc_size = getpagesize() * 8;
+    mf->realloc_size = ctx->page_size * 8;
 
     return mf;
 }

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -50,7 +50,7 @@ int cio_os_isdir(const char *dir)
 }
 
 /* Create directory */
-int cio_os_mkpath(const char *dir, mode_t mode)
+int cio_os_mkpath(const char *dir, cio_mode_t mode)
 {
     struct stat st;
     char *dup_dir = NULL;
@@ -85,7 +85,7 @@ int cio_os_mkpath(const char *dir, mode_t mode)
     if (!dup_dir) {
         return 1;
     }
-    cio_os_mkpath(dirname(dup_dir), mode);
+    cio_os_mkpath(cio_dirname(dup_dir), mode);
     free(dup_dir);
     return mkdir(dir, mode);
 #endif

--- a/src/cio_stream.c
+++ b/src/cio_stream.c
@@ -257,7 +257,7 @@ void cio_stream_destroy_all(struct cio_ctx *ctx)
 /* Return the total number of bytes being used by Chunks up in memory */
 size_t cio_stream_size_chunks_up(struct cio_stream *st)
 {
-    ssize_t bytes;
+    cio_ssize_t bytes;
     size_t total = 0;
     struct cio_chunk *ch;
     struct mk_list *head;

--- a/tools/cio.c
+++ b/tools/cio.c
@@ -267,7 +267,7 @@ static int cb_cmd_stdin(struct cio_ctx *ctx, const char *stream,
     int err;
     int meta_len;
     size_t total = 0;
-    ssize_t bytes;
+    cio_ssize_t bytes;
     char buf[1024*8];
     struct cio_stream *st;
     struct cio_chunk *ch;


### PR DESCRIPTION
This PR adds a prefix to the types and functions added in for compatibility reasons so they don't collide with those defined by fluent-bit.