### PR TITLE
file: allocation size adjustment

### DIFF
--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -358,6 +358,7 @@ static int mmap_file(struct cio_ctx *ctx, struct cio_chunk *ch, size_t size)
 
         cio_log_debug(ctx, "%s:%s adjusting size OK", ch->st->name, ch->name);
     }
+    cf->alloc_size = size;
 
     /* Map the file */
     size = ROUND_UP(size, ctx->page_size);
@@ -368,7 +369,6 @@ static int mmap_file(struct cio_ctx *ctx, struct cio_chunk *ch, size_t size)
         cio_log_error(ctx, "cannot mmap/read chunk '%s'", cf->path);
         return CIO_ERROR;
     }
-    cf->alloc_size = size;
 
     /* check content data size */
     if (fs_size > 0) {


### PR DESCRIPTION
alloc_size may need to reflect the true size of the file here, not the size rounded up. Trying to append to file does not write through when alloc_size misrepresents the true filesize because file resize not detected.

File resize needed on **chunk_down** -> **chunk_up** -> **append** because chunk_down truncates file extra space, chunk_up restores file with alloc_size misrepresenting true filesize (rounded non-truncated filesize) and append expects the file to be non-truncated size and the write fails. 

There are several solution options I tried which all work (the tests fail if none of the following are implemented)
1. Round up only mmap (_implemented_)
    - alloc_size not rounded up and represents true file size
    - Move `alloc_size = size` above round up. This keeps mmap length still a multiple of page size, but larger than true filesize
2. Don't round up alloc_size or mmap (_another option_ -- **Preferred but needs confirmation**)
    - Just delete the following ROUND_UP(size, ctx->page_size). mmap length is now the true length of the file.
    - This seems the most straightforward but I don't know if you want mmap to always allocate in increments of page size for some reason.
3. Actually resize the file (_another option_)
    - A file resize needed at least once before append since file truncated on let down.
    - Not needed if alloc_size is set since append would detect resize needed and will resize and remap.
    - Lazy may be better for cases with only read and no append
```
        /* add the following to the if (fs_size > 0) { ... } block */
        /* Round up filesize to allow for appends */
        size = ROUND_UP(size, ctx->page_size);
        ret = cio_file_fs_size_change(cf, size);
```
